### PR TITLE
added error messaging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: looker3
 Type: Package
 Title: looker3 (http://github.com/abelcastilloavant/avant-looker3)
 Description: Pull data from Looker using the fancy new 3.0 API.
-Version: 0.1.8
+Version: 0.1.9
 Author: Abel Castillo <abel.castillo@avant.com>
 Maintainer: Abel Castillo <abel.castillo@avant.com>
 Authors@R: c(person("Abel", "Castillo",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,7 @@ Imports:
 Suggests:
     testthat,
     withr
-Remotes:
-    peterhurford/checkr@0.0.4.9008,
+Remotes: peterhurford/checkr@0.0.4.9008,
     kirillseva/cacher@0.1.0
 Roxygen: list(wrap = FALSE)
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.1.9
+- Added an extra validation in `extract_query_response` to catch silent errors in the body of httr response objects.
+
 # Version 0.1.8
 - Also allow `filters` to be vector.
 

--- a/R/response_handlers.R
+++ b/R/response_handlers.R
@@ -41,6 +41,10 @@ handle_logout_response <- function(logout_response) {
 extract_query_result <- function(query_response) {
   validate_response(query_response)
   data_from_query <- httr::content(query_response)
+  if (grepl("^Error:", data_from_query)) {
+    # assume that the query errored quietly and that data_from_query is an error message.
+    stop("Looker returned the following error message:\n", as.character(data_from_query))
+  }
   readr::read_csv(data_from_query)
 }
 

--- a/man/looker3.Rd
+++ b/man/looker3.Rd
@@ -6,7 +6,7 @@
 \alias{looker3-package}
 \title{Describe the package.}
 \usage{
-looker3(model, view, fields, filters = list(), limit = 10)
+looker3(model, view, fields, filters = list(), limit = 1000)
 }
 \arguments{
 \item{model}{character. The \code{model} parameter of the query.}

--- a/man/run_inline_query.Rd
+++ b/man/run_inline_query.Rd
@@ -5,7 +5,7 @@
 \title{Run an inline query using the Looker 3.0 API.}
 \usage{
 run_inline_query(base_url, client_id, client_secret, model, view, fields,
-  filters, limit = 10)
+  filters, limit = 1000)
 }
 \arguments{
 \item{base_url}{character. The base url of the Looker server.}

--- a/tests/testthat/test-response_handlers.R
+++ b/tests/testthat/test-response_handlers.R
@@ -5,6 +5,8 @@ fake_login_response  <- list(status = "200",
 fake_logout_response <- list(status = "204")  
 fake_query_response  <- list(status = "200", 
                              body = "ID, VALUE \n 1, 2")
+silent_error_response <- list(status = "200",
+                              body = "Error: something went wrong despite the status code being successful")
 fake_query_failure   <- list(status = "500")
 fake_logout_failure  <- list(status = "500")
 
@@ -43,6 +45,11 @@ describe("processing successful responses", {
       # so let's remove them before making our comparison
       class(result) <- "data.frame"
       expect_equal(result, data.frame(ID = 1, VALUE = 2))
+    })
+    test_that("extract_query_result errors on 'silent' errors", {
+      
+      expect_error(extract_query_result(silent_error_response),
+                   "Error: ")
     })
   })  
 })


### PR DESCRIPTION
```
> do.call(looker3::looker3, args)
Error: 'Error: Invalid date filter syntax: "before 30 days"' does not exist in current working directory ('....').
```
This was caused by an error when `readr::read_csv` received the string `"Error: Invalid date filter syntax: \"before 30 days\""`. Since the string has no newlines, `readr::read_csv` assumed it was handed a file path, and tried (unsuccessfully!) to open the file. The error was not caught sooner because the status code of the response was `200`, so `validate_response` thought that the API call was successful.

This PR adds a validation in the `extract_query_response` helper to catch this sort of silent erroring.