### PR TITLE
add silent_read_csv param to run_inline_query

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: looker3
 Type: Package
 Title: looker3 (http://github.com/abelcastilloavant/avant-looker3)
 Description: Pull data from Looker using the fancy new 3.0 API.
-Version: 0.1.9
+Version: 0.1.10
 Author: Abel Castillo <abel.castillo@avant.com>
 Maintainer: Abel Castillo <abel.castillo@avant.com>
 Authors@R: c(person("Abel", "Castillo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.1.10
+- Added a param `silent_csv_read`, to switch off/on warnings while reading the stream into a data frame.
+
 # Version 0.1.9
 - Added an extra validation in `extract_query_response` to catch silent errors in the body of httr response objects.
 

--- a/R/looker3.R
+++ b/R/looker3.R
@@ -13,6 +13,8 @@
 #' @param filters list. Each element of the list is a length 2 character vector,
 #' each vector describing one of the \code{filters} of the query.
 #' @param limit numeric. The \code{limit} parameter of the query.
+#' @param silent_read_csv logical. Whether or not to suppress warnings
+#' when reading the streamed data into a data frame.
 #'
 #' @return a data.frame containing the data returned by the query
 #'
@@ -24,11 +26,13 @@ looker3 <- checkr::ensure(pre = list(   # model, view, and fields are
              filters %is% simple_string ||
                ((filters %is% list || filters %is% vector) &&
                 (filters %contains_only% simple_string || filters %is% empty)),
-             limit %is% numeric && limit > 0 && limit %% 1 == 0
+             limit %is% numeric && limit > 0 && limit %% 1 == 0,
+             silent_read_csv %is% logical
            ), 
 
   function(model, view, fields,
-               filters = list(), limit = 1000) {
+            filters = list(), limit = 1000,
+            silent_read_csv = TRUE) {
 
     env_var_descriptions <- list(
       LOOKER_URL    = "API url",

--- a/R/response_handlers.R
+++ b/R/response_handlers.R
@@ -38,13 +38,17 @@ handle_logout_response <- function(logout_response) {
   validate_response(logout_response)
 }
 
-extract_query_result <- function(query_response) {
+extract_query_result <- function(query_response, silent_read_csv = TRUE) {
   validate_response(query_response)
   data_from_query <- httr::content(query_response)
   if (grepl("^Error:", data_from_query)) {
     # assume that the query errored quietly and that data_from_query is an error message.
     stop("Looker returned the following error message:\n", as.character(data_from_query))
   }
-  readr::read_csv(data_from_query)
+  if (silent_read_csv) {
+    suppressWarnings(readr::read_csv(data_from_query))
+  } else {
+    readr::read_csv(data_from_query)
+  }
 }
 

--- a/R/run_inline_query.R
+++ b/R/run_inline_query.R
@@ -15,7 +15,7 @@
 #'
 run_inline_query <- function(base_url, client_id, client_secret, 
                       model, view, fields, filters, 
-                      limit = 1000) {
+                      limit = 1000, silent_read_csv) {
 
 
   # The API requires you to "log in" and obtain a session token
@@ -29,5 +29,5 @@ run_inline_query <- function(base_url, client_id, client_secret,
   inline_query_response <- query_api_call(base_url,
     model, view, fields, filters, limit) 
 
-  extract_query_result(inline_query_response)  
+  extract_query_result(inline_query_response, silent_read_csv)
 }

--- a/man/looker3.Rd
+++ b/man/looker3.Rd
@@ -6,7 +6,8 @@
 \alias{looker3-package}
 \title{Describe the package.}
 \usage{
-looker3(model, view, fields, filters = list(), limit = 1000)
+looker3(model, view, fields, filters = list(), limit = 1000,
+  silent_read_csv = TRUE)
 }
 \arguments{
 \item{model}{character. The \code{model} parameter of the query.}
@@ -19,6 +20,9 @@ looker3(model, view, fields, filters = list(), limit = 1000)
 each vector describing one of the \code{filters} of the query.}
 
 \item{limit}{numeric. The \code{limit} parameter of the query.}
+
+\item{silent_read_csv}{logical. Whether or not to suppress warnings
+when reading the streamed data into a data frame.}
 }
 \value{
 a data.frame containing the data returned by the query

--- a/man/run_inline_query.Rd
+++ b/man/run_inline_query.Rd
@@ -5,7 +5,7 @@
 \title{Run an inline query using the Looker 3.0 API.}
 \usage{
 run_inline_query(base_url, client_id, client_secret, model, view, fields,
-  filters, limit = 1000)
+  filters, limit = 1000, silent_read_csv)
 }
 \arguments{
 \item{base_url}{character. The base url of the Looker server.}

--- a/tests/testthat/test-run_inline_query.R
+++ b/tests/testthat/test-run_inline_query.R
@@ -80,7 +80,7 @@ describe("run_inline_query helpers called with the corresponding inputs", {
       test_that("extract_query_result receives the output of query_api_call", {
         with_mock(
           `looker3:::query_api_call` = function(...) "response received", 
-          `looker3:::extract_query_result` = function(inline_query_response) {
+          `looker3:::extract_query_result` = function(inline_query_response, ...) {
             stop(paste0("extract_query_result called: "), inline_query_response)  
           }, {
             expect_error(do.call(run_inline_query, args), 


### PR DESCRIPTION
There are times when `readr::read_csv` emits warning messages which can clutter the console. 

This PR adds a parameter to the main function, `silent_read_csv`, that allows you to suppress the warning messages in the call to `readr::read_csv` in the `extract_query_result` helper function.

A default value is set, so you won't have to modify your code. The default value is `TRUE`, so you can switch this to `FALSE` if you want to see the warnings for debugging purposes, etc.