### PR TITLE
include error message when response validation catches a failed API call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: looker3
 Type: Package
 Title: looker3 (http://github.com/abelcastilloavant/avant-looker3)
 Description: Pull data from Looker using the fancy new 3.0 API.
-Version: 0.1.11
+Version: 0.1.12
 Author: Abel Castillo <abel.castillo@avant.com>
 Maintainer: Abel Castillo <abel.castillo@avant.com>
 Authors@R: c(person("Abel", "Castillo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.1.12
+- Added message from the http response from Looker to error messages coming from `validate_response`.
+
 # Version 0.1.11
 - Fixed bug where `looker3` was not passing `silent_read_csv` to `run_inline_query`.
 

--- a/R/response_handlers.R
+++ b/R/response_handlers.R
@@ -21,7 +21,7 @@ validate_response <- function(response) {
     "The status code was",
     httr::status_code(response),
     "and the error message was",
-    httr::content(response)$message
+    httr::content(response)$message %||% "not provided"
     )
   )
 }

--- a/R/response_handlers.R
+++ b/R/response_handlers.R
@@ -17,9 +17,11 @@ validate_response <- function(response) {
 
   stop(paste("The",
     gsub("_", " ", deparse(substitute(response))),
-    "of your Looker query was not a successful response.",
-    "It returned a status code of",
-    httr::status_code(response)
+    "step in looker failed.",
+    "The status code was",
+    httr::status_code(response),
+    "and the error message was",
+    httr::content(response)$message
     )
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,1 @@
+`%||%` <- function(x, y) if (is.null(x)) y else x

--- a/tests/testthat/test-response_handlers.R
+++ b/tests/testthat/test-response_handlers.R
@@ -7,19 +7,31 @@ fake_query_response  <- list(status = "200",
                              body = "ID, VALUE \n 1, 2")
 silent_error_response <- list(status = "200",
                               body = "Error: something went wrong despite the status code being successful")
-fake_query_failure   <- list(status = "500")
-fake_logout_failure  <- list(status = "500")
+
+fake_query_failure   <- list(status = "500", error_message = "fake_error_message")
+fake_query_failure_without_message <- list(status = "500")
 
 
 with_mock(
   `httr::status_code` = function(x) x$status, 
-  `httr::content`     = function(...) list(message = "error message"), {
-  test_that("validate_response errors with step name and status code", {
+  `httr::content`     = function(x) list(message = x$error_message), {
+  test_that("validate_response errors with step name, status code, and error message", {
     expect_error(validate_response(fake_query_failure),
       "The fake query failure step in looker")
     expect_error(validate_response(fake_query_failure),
       "status code was 500")
-   })
+    expect_error(validate_response(fake_query_failure),
+      "fake_error_message")
+  })
+  test_that("validate_response yields step name and status code even if there's no message", {
+    expect_error(validate_response(fake_query_failure_without_message),
+      "The fake query failure without message step in looker")
+    expect_error(validate_response(fake_query_failure_without_message),
+      "status code was 500")
+    expect_error(validate_response(fake_query_failure_without_message),
+      "not provided")
+  
+  })
 })
 
 

--- a/tests/testthat/test-response_handlers.R
+++ b/tests/testthat/test-response_handlers.R
@@ -11,12 +11,14 @@ fake_query_failure   <- list(status = "500")
 fake_logout_failure  <- list(status = "500")
 
 
-with_mock(`httr::status_code` = function(x) x$status, {
+with_mock(
+  `httr::status_code` = function(x) x$status, 
+  `httr::content`     = function(...) list(message = "error message"), {
   test_that("validate_response errors with step name and status code", {
     expect_error(validate_response(fake_query_failure),
-      "The fake query failure of your Looker query")
+      "The fake query failure step in looker")
     expect_error(validate_response(fake_query_failure),
-      "returned a status code of 500")
+      "status code was 500")
    })
 })
 


### PR DESCRIPTION
When looker responds to a failed request, it gives you a message with some clue as to why the request failed. This PR extracts that message and drops it in the error message coming from `validate_response`.