### PR TITLE
Warn when number of columns returned doesn't match number of fields provided

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: looker3
 Type: Package
 Title: looker3 (http://github.com/abelcastilloavant/avant-looker3)
 Description: Pull data from Looker using the fancy new 3.0 API.
-Version: 0.1.12
+Version: 0.1.13
 Author: Abel Castillo <abel.castillo@avant.com>
 Maintainer: Abel Castillo <abel.castillo@avant.com>
 Authors@R: c(person("Abel", "Castillo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.1.13
+- Added a warning if the number of columns returned is different from the number of fields provided.
+
 # Version 0.1.12
 - Added message from the http response from Looker to error messages coming from `validate_response`.
 

--- a/R/looker3.R
+++ b/R/looker3.R
@@ -77,10 +77,3 @@ looker3 <- checkr::ensure(pre = list(   # model, view, and fields are
   }
 )
 
-colon_split_to_list <- function(string) {
-  colon_split <- strsplit(string, ": ")
-  field_names <- lapply(colon_split, `[[`, 1)
-  values <- lapply(colon_split, `[[`, 2)
-  names(values) <- field_names
-  values
-}

--- a/R/run_inline_query.R
+++ b/R/run_inline_query.R
@@ -18,9 +18,7 @@ run_inline_query <- function(base_url, client_id, client_secret,
                       limit = 1000, silent_read_csv) {
 
 
-  # The API requires you to "log in" and obtain a session token
-  # TODO: find a way to cache the session token, perhaps using memoise package?
-
+  # The API requires you to have an access token obtained by "logging in".
   if (cached_token_is_invalid()) {
     login_response <- login_api_call(base_url, client_id, client_secret)
     put_new_token_in_cache(login_response)
@@ -29,5 +27,12 @@ run_inline_query <- function(base_url, client_id, client_secret,
   inline_query_response <- query_api_call(base_url,
     model, view, fields, filters, limit) 
 
-  extract_query_result(inline_query_response, silent_read_csv)
+  output <- extract_query_result(inline_query_response, silent_read_csv)
+
+  if (ncol(output) != length(fields)) {
+    warning(paste("Looker data has", ncol(output), "columns,",
+            "but", length(fields), "fields provided."))
+  }
+  output
+
 }

--- a/R/run_inline_query.R
+++ b/R/run_inline_query.R
@@ -27,12 +27,13 @@ run_inline_query <- function(base_url, client_id, client_secret,
   inline_query_response <- query_api_call(base_url,
     model, view, fields, filters, limit) 
 
-  output <- extract_query_result(inline_query_response, silent_read_csv)
+  output   <- extract_query_result(inline_query_response, silent_read_csv)
+  colnames <- names(output)
 
-  if (ncol(output) != length(fields)) {
-    warning(paste("Looker data has", ncol(output), "columns,",
-            "but", length(fields), "fields provided."))
+  if (length(colnames) != length(fields)) {
+    warning(paste("Number of columns returned doesn't match number of fields provided.",
+      "\n Looker data column names:", paste0(colnames, collapse = ", "),
+      "\n fields provided:", paste0(list_to_colon_split(fields), collapse = ", "))paste("Looker data has", ncol(output), "columns,",
   }
   output
-
 }

--- a/R/run_inline_query.R
+++ b/R/run_inline_query.R
@@ -33,7 +33,8 @@ run_inline_query <- function(base_url, client_id, client_secret,
   if (length(colnames) != length(fields)) {
     warning(paste("Number of columns returned doesn't match number of fields provided.",
       "\n Looker data column names:", paste0(colnames, collapse = ", "),
-      "\n fields provided:", paste0(list_to_colon_split(fields), collapse = ", "))paste("Looker data has", ncol(output), "columns,",
+      "\n fields provided:", paste0(list_to_colon_split(fields), collapse = ", "))
+    )
   }
   output
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,1 +1,13 @@
 `%||%` <- function(x, y) if (is.null(x)) y else x
+
+colon_split_to_list <- function(string) {
+  colon_split <- strsplit(string, ": ")
+  field_names <- lapply(colon_split, `[[`, 1)
+  values <- lapply(colon_split, `[[`, 2)
+  names(values) <- field_names
+  values
+}
+
+list_to_colon_split <- function(list) {
+  paste(names(list), list, sep = ": ") %>% unlist
+}


### PR DESCRIPTION
When making a query, the expectation is to receive one column per field provided. This PR adds a warning if that expectation is not satisfied.

I considered giving an error instead of a warning, but I want the user to receive data - e.g. if the user makes an expensive query, I'd like the user to at least have a chance to inspect the columns actually pulled.