### PR TITLE
fix messaging bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: looker3
 Type: Package
 Title: looker3 (http://github.com/abelcastilloavant/avant-looker3)
 Description: Pull data from Looker using the fancy new 3.0 API.
-Version: 0.1.13
+Version: 0.1.14
 Author: Abel Castillo <abel.castillo@avant.com>
 Maintainer: Abel Castillo <abel.castillo@avant.com>
 Authors@R: c(person("Abel", "Castillo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Version 0.1.14
+- Fixed bug where `validate_response` would crash if the response object was not a list.
+
 # Version 0.1.13
 - Added a warning if the number of columns returned is different from the number of fields provided.
 

--- a/tests/testthat/test-run_inline_query.R
+++ b/tests/testthat/test-run_inline_query.R
@@ -16,7 +16,6 @@ describe("run_inline_query helpers called with the corresponding inputs", {
     `looker3:::logout_api_call` = function(...) NULL,
     `looker3:::cached_token_is_invalid` = function(...) FALSE,
     `looker3:::query_api_call` = function(...) NULL,
-    `looker3:::handle_logout_response` = function(...) NULL,
     `looker3:::extract_query_result` = function(...) NULL, {
 
       test_that("login_api_call called if cached token is invalid", {


### PR DESCRIPTION
resolves https://github.com/avantcredit/looker3/issues/33:
```
> devtools::load_all("path/to/looker3")
> looker3::looker3("invalid_model", "view", "fields", "filters")
Error in validate_response(query_response) :
  The query response step in looker failed. The status code was 403 and the error message was {"message":"Forbidden","documentation_url":"http://docs.looker.com/"}
```